### PR TITLE
update versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@
 source 'https://rubygems.org'
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby '3.1.2'
+ruby '~> 3.1.2'
 
 # Bundle edge Rails instead: gem "rails", github: "rails/rails", branch: "main"
 gem 'rails', '~> 7.0.3'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -221,6 +221,7 @@ GEM
       ruby2_keywords (>= 0.0.4)
     faraday-net_http (3.0.2)
     ffi (1.15.5)
+    ffi (1.15.5-x64-mingw-ucrt)
     globalid (1.0.0)
       activesupport (>= 5.0)
     hashie (5.0.0)
@@ -280,6 +281,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.8)
+    nokogiri (1.13.10-x64-mingw-ucrt)
+      racc (~> 1.4)
     nokogiri (1.13.10-x86_64-darwin)
       racc (~> 1.4)
     orm_adapter (0.5.0)
@@ -370,6 +373,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.5.4-x64-mingw-ucrt)
     sqlite3 (1.5.4-x86_64-darwin)
     sys-uname (1.2.2)
       ffi (~> 1.1)
@@ -400,6 +404,7 @@ GEM
     zeitwerk (2.6.6)
 
 PLATFORMS
+  x64-mingw-ucrt
   x86_64-darwin-20
 
 DEPENDENCIES


### PR DESCRIPTION
ruby version can be greater than or equal to `3.1.2`  fixes problems when setting up the project for the first time ( if user installs latest version of ruby ).

Ruby 3 also prioritizes backward-compatibility for all of its changes that means apps built on older Ruby versions will still function normally